### PR TITLE
Fix bug in disabling softmax in TF models

### DIFF
--- a/ood_enabler/model_modifier/tf_modifier.py
+++ b/ood_enabler/model_modifier/tf_modifier.py
@@ -20,7 +20,7 @@ class TFModifier(ModelModifier):
         return: transformed OOD Model
         """
         model = model_wrapper.model
-        model.get_layer("predictions").activations = None
+        model.get_layer("predictions").activation = None
 
         ood_model = Model(inputs=model.input,
                           outputs=[model.get_layer("predictions").output,


### PR DESCRIPTION
The property `activations` of the prediction layer should be `activation` (without `s`) instead. 